### PR TITLE
Updated module name to common package syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SD-1` Added exhaustive types for filters, sorting, views, and signals.
 Also, added basic screening and scraping functions.
 
+### Fixed
+- `SD-2` Updated module name to common package syntax
+
 ### Improvements
 - `SD-1` Updated the README with more documentation coverage.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module finviz
+module github.com/d3an/finviz
 
 go 1.14
 


### PR DESCRIPTION
Closes #3 Updated module name `go.mod` from `finviz` to `github.com/d3an/finviz`