### PR TITLE
Refactored client generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-    df, err := GetScreenerData(NewClient(), &PerformanceScreenerView{}, &map[string]interface{}{
+    df, err := GetScreenerData(nil, &PerformanceScreenerView{}, &map[string]interface{}{
         "signal": TopGainers,
         "general_order": Descending,
         "specific_order": ChangeFromOpen,

--- a/client.go
+++ b/client.go
@@ -36,24 +36,13 @@ func addHeaderTransport(t http.RoundTripper) *HeaderTransport {
 	return &HeaderTransport{t}
 }
 
-// NewClient generates a new client instance
-func NewClient() *http.Client {
-	return &http.Client{
-		Timeout:   30 * time.Second,
-		Transport: addHeaderTransport(nil),
-	}
-}
-
-// NewTestingClient generates a new testing client instance that uses go-vcr
-func NewTestingClient(rec *recorder.Recorder) *http.Client {
-	return &http.Client{
+// MakeGetRequest is used to get a byte array of the screen given a valid URL
+func MakeGetRequest(rec *recorder.Recorder, url string) ([]byte, error) {
+	c := &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: addHeaderTransport(rec),
 	}
-}
 
-// MakeGetRequest is used to get a byte array of the screen given a valid URL
-func MakeGetRequest(c *http.Client, url string) ([]byte, error) {
 	// Set up GET request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/finviz/cmd/news/news.go
+++ b/finviz/cmd/news/news.go
@@ -30,7 +30,7 @@ var (
 				er(err)
 			}
 
-			df, err := news.GetNewsData(finviz.NewClient(), viewInterface)
+			df, err := news.GetNewsData(nil, viewInterface)
 			if err != nil {
 				er(err)
 			}

--- a/finviz/cmd/quote/quote.go
+++ b/finviz/cmd/quote/quote.go
@@ -25,7 +25,7 @@ var (
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
 
-			df, err := quote.GetQuoteData(finviz.NewClient(), &map[string]interface{}{
+			df, err := quote.GetQuoteData(nil, &map[string]interface{}{
 				"tickers": tickerArgs,
 			})
 			if err != nil {

--- a/finviz/cmd/screener/screener.go
+++ b/finviz/cmd/screener/screener.go
@@ -89,9 +89,7 @@ var (
 				er(err)
 			}
 
-			client := finviz.NewClient()
-
-			df, err := GetScreenerData(client, viewInterface, &map[string]interface{}{
+			df, err := GetScreenerData(nil, viewInterface, &map[string]interface{}{
 				"signal":         signal,
 				"general_order":  generalOrder,
 				"specific_order": specificOrder,

--- a/news/helpers.go
+++ b/news/helpers.go
@@ -7,18 +7,18 @@ package news
 
 import (
 	"github.com/d3an/finviz"
+	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/go-gota/gota/dataframe"
-	"net/http"
 )
 
 // GetNewsData returns a DataFrame containing recent news data
-func GetNewsData(c *http.Client, v finviz.ViewInterface) (*dataframe.DataFrame, error) {
+func GetNewsData(rec *recorder.Recorder, v finviz.ViewInterface) (*dataframe.DataFrame, error) {
 	url, err := v.GenerateURL(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	html, err := finviz.MakeGetRequest(c, url)
+	html, err := finviz.MakeGetRequest(rec, url)
 	if err != nil {
 		return nil, err
 	}

--- a/news/tests/news_views_test.go
+++ b/news/tests/news_views_test.go
@@ -67,7 +67,7 @@ func TestNewsView_Scrape(t *testing.T) {
 		}
 
 		// Scraping test
-		df, err := news.GetNewsData(finviz.NewTestingClient(r), testInput.viewInterface)
+		df, err := news.GetNewsData(r, testInput.viewInterface)
 		if err != nil {
 			t.Error(err)
 		}

--- a/quote/tests/views_test.go
+++ b/quote/tests/views_test.go
@@ -97,7 +97,7 @@ func TestQuoteView_Scrape(t *testing.T) {
 			t.Error(err)
 		}
 
-		html, err := finviz.MakeGetRequest(finviz.NewTestingClient(r), url)
+		html, err := finviz.MakeGetRequest(r, url)
 		if err != nil {
 			t.Error(err)
 		}
@@ -165,7 +165,7 @@ func TestQuoteView_MapScrape(t *testing.T) {
 			t.Error(err)
 		}
 
-		html, err := finviz.MakeGetRequest(finviz.NewTestingClient(r), url)
+		html, err := finviz.MakeGetRequest(r, url)
 		if err != nil {
 			t.Error(err)
 		}
@@ -208,7 +208,7 @@ func TestGetQuoteData(t *testing.T) {
 			t.Error(err)
 		}
 
-		df, err := quote.GetQuoteData(finviz.NewTestingClient(r), ti.viewArgs)
+		df, err := quote.GetQuoteData(r, ti.viewArgs)
 		if err != nil {
 			t.Error(err)
 		}

--- a/screener/helpers.go
+++ b/screener/helpers.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"github.com/PuerkitoBio/goquery"
 	"github.com/d3an/finviz"
+	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/go-gota/gota/dataframe"
 	"github.com/go-gota/gota/series"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
@@ -385,13 +385,13 @@ func getOrderValue(viewArgs *map[string]interface{}) string {
 }
 
 // GetScreenerData returns a DataFrame with screener data results
-func GetScreenerData(c *http.Client, v finviz.ViewInterface, viewArgs *map[string]interface{}) (*dataframe.DataFrame, error) {
+func GetScreenerData(rec *recorder.Recorder, v finviz.ViewInterface, viewArgs *map[string]interface{}) (*dataframe.DataFrame, error) {
 	url, err := v.GenerateURL(viewArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	html, err := finviz.MakeGetRequest(c, url)
+	html, err := finviz.MakeGetRequest(rec, url)
 	if err != nil {
 		return nil, err
 	}

--- a/screener/tests/views_test.go
+++ b/screener/tests/views_test.go
@@ -587,7 +587,7 @@ func TestScreenerView_GetData(t *testing.T) {
 		}
 
 		// Scraping Test
-		df, err := screener.GetScreenerData(finviz.NewTestingClient(r), ti.viewInterfaceType, &ti.viewArgs)
+		df, err := screener.GetScreenerData(r, ti.viewInterfaceType, &ti.viewArgs)
 		if err != nil {
 			t.Errorf("GetData function failed. Error: %v", err)
 		}
@@ -650,7 +650,7 @@ func TestCleanDataFrame(t *testing.T) {
 		}
 
 		// Scraping Test
-		df, err := screener.GetScreenerData(finviz.NewTestingClient(r), ti.viewInterface, &ti.viewArgs)
+		df, err := screener.GetScreenerData(r, ti.viewInterface, &ti.viewArgs)
 		if err != nil {
 			t.Errorf("GetData function failed. Error: %v", err)
 		}


### PR DESCRIPTION
- Removed `finviz.NewClient` and `finviz.NewTestingClient` functions.
- `finviz.MakeGetRequest` now consumes a `*recorder.Recorder` argument instead of `*http.Client`.
- This change generates new clients per request to increase the probability of valid responses.

Closes #68 